### PR TITLE
Expansions to the pytest prometheus plugin

### DIFF
--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -84,21 +84,21 @@ class PrometheusReport:
 
         passed_metric = Gauge(self._make_metric_name("passed"),
                 "Number of passed tests",
-                self.extra_labels.keys(), # This is in the original code, but why?
+                self.extra_labels.keys(),
                 registry=self.registry)
-        passed_metric.set(self.passed)
+        passed_metric.labels(**self.extra_labels).set(self.passed)
 
         failed_metric = Gauge(self._make_metric_name("failed"),
                 "Number of failed tests",
-                self.extra_labels.keys(), # This is in the original code, but why?
+                self.extra_labels.keys(),
                 registry=self.registry)
-        failed_metric.set(self.failed)
+        failed_metric.labels(**self.extra_labels).set(self.failed)
 
         skipped_metric = Gauge(self._make_metric_name("skipped"),
                 "Number of skipped tests",
-                self.extra_labels.keys(), # This is in the original code, but why?
+                self.extra_labels.keys(),
                 registry=self.registry)
-        skipped_metric.set(self.skipped)
+        skipped_metric.labels(**self.extra_labels).set(self.skipped)
 
         push_to_gateway(self.pushgateway_url, registry=self.registry, job=self.job_name)
 

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -1,5 +1,5 @@
-from prometheus_client import CollectorRegistry, Gauge, push_to_gateway, generate_latest
 import logging
+from prometheus_client import CollectorRegistry, Gauge, push_to_gateway
 
 def pytest_addoption(parser):
     group = parser.getgroup('terminal reporting')

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -1,4 +1,4 @@
-from prometheus_client import CollectorRegistry, Gauge, push_to_gateway, generate_latest
+from prometheus_client import CollectorRegistry, Gauge, pushadd_to_gateway, generate_latest
 
 def pytest_addoption(parser):
     group = parser.getgroup('terminal reporting')
@@ -53,4 +53,4 @@ class PrometheusReport:
             print("Pushing metric {name}".format(name=name))
             metric = Gauge(name, report.nodeid, self.extra_labels.keys(), registry=registry)
             metric.labels(**self.extra_labels).set(1 if report.outcome == 'passed' else 0)
-            push_to_gateway(self.pushgateway_url, registry=registry, job=self.job_name)
+            pushadd_to_gateway(self.pushgateway_url, registry=registry, job=self.job_name)

--- a/pytest_prometheus/__init__.py
+++ b/pytest_prometheus/__init__.py
@@ -50,6 +50,7 @@ class PrometheusReport:
                 prefix=self.prefix,
                 funcname=report.location[2]
             )
+            print("Pushing metric {name}".format(name=name))
             metric = Gauge(name, report.nodeid, self.extra_labels.keys(), registry=registry)
             metric.labels(**self.extra_labels).set(1 if report.outcome == 'passed' else 0)
             push_to_gateway(self.pushgateway_url, registry=registry, job=self.job_name)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='pytest-prometheus',
-    version='0.1',
+    version='0.2',
     description='Report test pass / failures to a Prometheus PushGateway',
     author='Yuvi Panda',
     author_email='yuvipanda@gmail.com',


### PR DESCRIPTION
Main things changed:

1) Waits until the end to push to the pushgateway, instead of doing so after every test finishes
2) Collects the number of failed, passed, and skipped tests and sends those as metrics to the pushgateway as well. I was picturing an alert that watches the metric for failed tests and that would alarm us if it went above zero and stayed there for several minutes (indicating a prolonged failure and not just a test blip)